### PR TITLE
chore: modernize to AWS CDK v2, remove hardcoded secret, add tests + CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+    env:
+      JUPYTER_ADMIN_TEMP_PASSWORD: CiOnlyTempPassw0rd!
+      DEPLOYER_IP_CIDR: 203.0.113.10/32
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install AWS CDK CLI
+        run: npm i -g aws-cdk
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Run tests
+        run: pytest --cov=cdk --cov-report=term-missing
+
+      - name: CDK synth
+        run: cdk synth

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 package-lock.json
 __pycache__
 .pytest_cache
+.coverage
+.coverage.*
+htmlcov
 .env
 .venv
 *.egg-info

--- a/Pipfile
+++ b/Pipfile
@@ -1,15 +1,17 @@
 [[source]]
-url = 'https://pypi.python.org/simple'
+url = 'https://pypi.org/simple'
 verify_ssl = true
 
 [dev-packages]
 jupyter_ecs_service = {editable = true,path = "cdk"}
+pytest = ">=8"
+pytest-cov = ">=5"
 
 [packages]
-boto3 = "*"
-dictdiffer = "*"
-mypy_boto3 = "*"
-boto3_type_annotations = "*"
+aws-cdk-lib = ">=2.100.0,<3.0.0"
+constructs = ">=10.0.0,<11.0.0"
+PyYAML = ">=6.0"
+boto3 = ">=1.34,<2"
 
 [requires]
-python_version = "3"
+python_version = "3.11"

--- a/README.md
+++ b/README.md
@@ -24,43 +24,68 @@ This architecture is using EFS as a shared, persistent storage for storing the J
 - Domain name managed with a public hosted zone on AWS Route 53. 
   Please collect this information and fill the `config.yaml` file with the hosted zone name and hosted zone id from Route 53.
 - MacOS / Linux computer with Docker: https://docs.docker.com/get-docker/
-- NodeJS 12 or later AWS CDK command line interface installed on your computer.
-  You can easily install AWS CDK command line interface it using `npm`:
+- NodeJS 20 or later with the AWS CDK v2 command line interface installed on your computer.
+  You can easily install the AWS CDK command line interface using `npm`:
 
   ```
   $ npm install -g aws-cdk
   ```
-- Python 3.6 and up with Pipenv dependencies & virtual environment management framework.
-  You can easily install Pipenv command line interface it using `pip`:
-  
+- Python 3.9 and up. Dependencies can be managed either with plain `pip`
+  (`requirements-dev.txt`) or with Pipenv.
+
   ```
   $ pip install --upgrade pipenv
   ```
 
+### Required environment variables
+
+This project no longer stores any secrets in `config.yaml`. The following
+environment variables must be set at synth/deploy time:
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `JUPYTER_ADMIN_TEMP_PASSWORD` | Yes | Cognito temporary password assigned to the admin users listed in `docker/admins`. The stack fails fast if it is not set. It must be changed on first login. |
+| `DEPLOYER_IP_CIDR` | No | CIDR (e.g. `203.0.113.10/32`) allowed to reach the public load balancer on HTTPS. If unset, the deployer's public IP is resolved automatically via `checkip.amazonaws.com` at synth time. Set it explicitly for offline synth/CI. |
+
+```
+$ export JUPYTER_ADMIN_TEMP_PASSWORD='ChangeMeOnFirstLogin!'
+$ export DEPLOYER_IP_CIDR='203.0.113.10/32'   # optional
+```
+
 ### Preparing the CDK Environment
 
-To initiate the virtualenv on MacOS and Linux and install the required dependencies:
+This project targets **AWS CDK v2** (`aws-cdk-lib` / `constructs`).
+
+Using plain `pip` and a virtual environment:
+
+```
+$ python3 -m venv .venv
+$ source .venv/bin/activate
+$ pip install -r requirements-dev.txt
+```
+
+Alternatively, using Pipenv:
 
 ```
 $ pipenv install --dev
-```
-
-After the init process completes, and the virtualenv is created, you can use the following
-step to activate your virtualenv.
-
-```
 $ pipenv shell
 ```
 
-At this point you can now synthesize the CloudFormation template for this code.
+At this point you can synthesize the CloudFormation template for this code
+(remember to export the required environment variables first):
 
 ```
 $ cdk synth
 ```
 
-To add additional dependencies, for example other CDK libraries, just add
-them to your `setup.py` file and run `pipenv --lock && pipenv sync`
-command.
+You can run the unit tests with:
+
+```
+$ pytest --cov=cdk --cov-report=term-missing
+```
+
+To add additional dependencies, add them to `requirements.txt` /
+`cdk/setup.py` (or the `Pipfile`) and reinstall.
 
 ### Deployment
 
@@ -95,7 +120,9 @@ However, if you're using your own docker image you can change the admin user lis
 
 ## Security
 
-- You should configure the admin user temporary password on the `config.yaml` file.
+- The admin user temporary password is supplied via the `JUPYTER_ADMIN_TEMP_PASSWORD` environment variable (it is no longer stored in `config.yaml`).
+  Note that this temporary password is rendered into the synthesized CloudFormation template on the deployer's machine (it is **not** committed to this repository).
+  Treat the generated template/artifacts as sensitive, and change the password on first login.
 - Authentication to the Jupyter hub is done by AWS Cognito user pool. When a user is logging in to the system, a user directory is automatically created for him.
 - Jupyter `Shutdown on logout` is activated, To make sure that ghost processes are closed.  
 - ECS containers are running in non-privileged mode, according to the docker best practices.

--- a/app.py
+++ b/app.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
-import os
+import aws_cdk as cdk
 
-from aws_cdk import core as cdk
 from cdk.jupyter_ecs_service.jupyter_ecs_service_stack import JupyterEcsServiceStack
 from cdk.jupyter_ecs_service.constants import BASE_NAME
 

--- a/cdk.json
+++ b/cdk.json
@@ -1,17 +1,25 @@
 {
   "app": "python3 app.py",
+  "watch": {
+    "include": ["**"],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "requirements*.txt",
+      "**/__init__.py",
+      "**/__pycache__",
+      "tests"
+    ]
+  },
   "context": {
-    "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
-    "@aws-cdk/core:enableStackNameDuplicates": "true",
-    "aws-cdk:enableDiffNoFail": "true",
-    "@aws-cdk/core:stackRelativeExports": "true",
-    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
-    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
-    "@aws-cdk/aws-kms:defaultKeyPolicies": true,
-    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
-    "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true,
-    "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
-    "@aws-cdk/aws-efs:defaultEncryptionAtRest": true,
-    "@aws-cdk/aws-lambda:recognizeVersionProps": true
+    "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
+    "@aws-cdk/core:checkSecretUsage": true,
+    "@aws-cdk/core:target-partitions": ["aws", "aws-cn"],
+    "@aws-cdk/aws-iam:minimizePolicies": true,
+    "@aws-cdk/core:validateSnapshotRemovalPolicy": true,
+    "@aws-cdk/core:newStyleStackSynthesis": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/aws-ecs:arnFormatIncludesClusterName": true,
+    "@aws-cdk/aws-efs:denyAnonymousAccess": true
   }
 }

--- a/cdk/jupyter_ecs_service/jupyter_ecs_service_stack.py
+++ b/cdk/jupyter_ecs_service/jupyter_ecs_service_stack.py
@@ -1,7 +1,11 @@
-import yaml
+import os
 import urllib.request
 
+import yaml
 from aws_cdk import (
+    Stack,
+    RemovalPolicy,
+    CfnOutput,
     aws_ec2 as ec2,
     aws_ecs as ecs,
     aws_efs as efs,
@@ -15,21 +19,31 @@ from aws_cdk import (
     custom_resources as cr,
     aws_logs as logs,
     aws_kms as kms,
-    core as cdk
 )
+from constructs import Construct
 
-from constants import BASE_NAME
+from .constants import BASE_NAME
 
 
-class JupyterEcsServiceStack(cdk.Stack):
+class JupyterEcsServiceStack(Stack):
 
-    def __init__(self, scope: cdk.Construct, id: str, **kwargs) -> None:
+    def __init__(self, scope: Construct, id: str, **kwargs) -> None:
         super().__init__(scope, id, **kwargs)
 
         # General configuration variables
 
         config_yaml = yaml.load(
             open('config.yaml'), Loader=yaml.FullLoader)
+
+        # Admin temporary password is sourced from the environment instead of
+        # being committed to config.yaml. It is a Cognito temporary password
+        # that must be changed on first login. Fail fast if it is missing.
+        admin_temp_password = os.environ.get('JUPYTER_ADMIN_TEMP_PASSWORD')
+        if not admin_temp_password:
+            raise ValueError(
+                'JUPYTER_ADMIN_TEMP_PASSWORD environment variable must be set '
+                '(this value was previously hardcoded in config.yaml).'
+            )
 
         domain_prefix = config_yaml['domain_prefix']
 
@@ -102,8 +116,12 @@ class JupyterEcsServiceStack(cdk.Stack):
 
         # Open ingress to the deploying computer public IP
 
-        my_ip_cidr = urllib.request.urlopen(
-            'http://checkip.amazonaws.com').read().decode('utf-8').strip() + '/32'
+        # Allow overriding the deployer IP (used for offline synth/tests);
+        # otherwise resolve the current public IP at synth time.
+        my_ip_cidr = os.environ.get('DEPLOYER_IP_CIDR')
+        if not my_ip_cidr:
+            my_ip_cidr = urllib.request.urlopen(
+                'http://checkip.amazonaws.com').read().decode('utf-8').strip() + '/32'
         jupyter_lb_security_group.add_ingress_rule(
             peer=ec2.Peer.ipv4(cidr_ip=my_ip_cidr),
             connection=ec2.Port.tcp(port=443),
@@ -141,8 +159,7 @@ class JupyterEcsServiceStack(cdk.Stack):
             description='CMK for EFS Encryption',
             enabled=True,
             enable_key_rotation=True,
-            trust_account_identities=True,
-            removal_policy=cdk.RemovalPolicy.DESTROY
+            removal_policy=RemovalPolicy.DESTROY
         )
 
         jupyter_efs = efs.FileSystem(
@@ -150,9 +167,9 @@ class JupyterEcsServiceStack(cdk.Stack):
             f'{BASE_NAME}EFS',
             vpc=jupyter_vpc,
             vpc_subnets=ec2.SubnetSelection(
-                subnet_type=ec2.SubnetType.PRIVATE),
+                subnet_type=ec2.SubnetType.PRIVATE_WITH_EGRESS),
             security_group=jupyter_efs_security_group,
-            removal_policy=cdk.RemovalPolicy.DESTROY,
+            removal_policy=RemovalPolicy.DESTROY,
             encrypted=True,
             kms_key=jupyter_efs_cmk
         )
@@ -216,7 +233,7 @@ class JupyterEcsServiceStack(cdk.Stack):
         cognito_user_pool = cognito.UserPool(
             self,
             f'{BASE_NAME}UserPool',
-            removal_policy=cdk.RemovalPolicy.DESTROY
+            removal_policy=RemovalPolicy.DESTROY
         )
 
         cognito_user_pool_domain = cognito.UserPoolDomain(
@@ -355,7 +372,7 @@ class JupyterEcsServiceStack(cdk.Stack):
                         action='adminCreateUser',
                         parameters={'UserPoolId': cognito_user_pool.user_pool_id,
                                     'Username': line.strip(),
-                                    'TemporaryPassword': config_yaml['admin_temp_password']},
+                                    'TemporaryPassword': admin_temp_password},
                         physical_resource_id=cr.PhysicalResourceId.of(
                             cognito_user_pool.user_pool_id)
                     )
@@ -363,7 +380,7 @@ class JupyterEcsServiceStack(cdk.Stack):
 
         # Output the service URL to CloudFormation outputs
 
-        cdk.CfnOutput(
+        CfnOutput(
             self,
             f'{BASE_NAME}JupyterHubURL',
             value='https://' + jupyter_route53_record.domain_name

--- a/cdk/setup.py
+++ b/cdk/setup.py
@@ -19,24 +19,12 @@ setuptools.setup(
     packages=setuptools.find_packages(where="jupyter_ecs_service"),
 
     install_requires=[
-        "aws-cdk.core>=1.107.0",
-        "aws-cdk.aws-iam>=1.107.0",
-        "aws-cdk.aws-cognito>=1.107.0",
-        "aws-cdk.aws_ec2>=1.107.0",
-        "aws-cdk.aws_ecs>=1.107.0",
-        "aws-cdk.aws-ecs-patterns>=1.107.0",
-        "aws-cdk.aws_efs>=1.107.0",
-        "aws_cdk.aws_certificatemanager>=1.107.0",
-        "aws_cdk.aws_route53>=1.107.0",
-        "aws_cdk.aws_route53_targets>=1.107.0",
-        "aws_cdk.aws_elasticloadbalancingv2>=1.107.0",
-        "aws_cdk.aws_logs>=1.107.0",
-        "aws_cdk.aws_kms>=1.107.0",
-        "aws_cdk.custom_resources>=1.107.0",
-        "PyYAML>=5.3.1",
+        "aws-cdk-lib>=2.100.0,<3.0.0",
+        "constructs>=10.0.0,<11.0.0",
+        "PyYAML>=6.0",
     ],
 
-    python_requires=">=3.6",
+    python_requires=">=3.9",
 
     classifiers=[
         "Development Status :: 4 - Beta",
@@ -45,9 +33,11 @@ setuptools.setup(
 
         "Programming Language :: JavaScript",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
 
         "Topic :: Software Development :: Code Generators",
         "Topic :: Utilities",

--- a/config.yaml
+++ b/config.yaml
@@ -5,7 +5,8 @@ hosted_zone_id: 'XXXXXXXXXXXXXXXXXXXXX'
 hosted_zone_name: 'some-domain.com'
 
 container_image: 'avishaybar/jupyter-ecs-service'
-admin_temp_password: '1Qaz2wsx!'
+# admin_temp_password is no longer stored here — set it via the
+# JUPYTER_ADMIN_TEMP_PASSWORD environment variable at synth/deploy time.
 num_containers: 1
 
 oauth_login_service_name: 'AWS Cognito'

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,12 @@
+import os
+import sys
+
+# Ensure the repository root is importable so `from cdk.jupyter_ecs_service...`
+# resolves regardless of the directory pytest is invoked from.
+REPO_ROOT = os.path.dirname(os.path.abspath(__file__))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+# The stack reads relative paths (config.yaml, docker/admins) at synth time, so
+# run tests from the repository root.
+os.chdir(REPO_ROOT)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest>=8
+pytest-cov>=5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+aws-cdk-lib>=2.100.0,<3.0.0
+constructs>=10.0.0,<11.0.0
+PyYAML>=6.0

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -1,0 +1,89 @@
+import os
+
+import aws_cdk as cdk
+import pytest
+from aws_cdk.assertions import Match, Template
+
+from cdk.jupyter_ecs_service.constants import BASE_NAME
+from cdk.jupyter_ecs_service.jupyter_ecs_service_stack import (
+    JupyterEcsServiceStack,
+)
+
+# The password previously hardcoded in config.yaml. Kept here purely so the
+# regression test can assert it never leaks into the synthesized template.
+OLD_HARDCODED_PASSWORD = "1Qaz2wsx!"
+
+
+@pytest.fixture(scope="module")
+def template():
+    # Provide the env vars the stack requires so synth works offline and does
+    # not attempt a network call to resolve the deployer IP.
+    os.environ["JUPYTER_ADMIN_TEMP_PASSWORD"] = "TestOnlyTempPassw0rd!"
+    os.environ["DEPLOYER_IP_CIDR"] = "203.0.113.10/32"
+
+    app = cdk.App()
+    stack = JupyterEcsServiceStack(
+        app,
+        BASE_NAME,
+        env=cdk.Environment(account="123456789012", region="us-east-1"),
+    )
+    return Template.from_stack(stack)
+
+
+def test_ecs_service_present(template):
+    template.resource_count_is("AWS::ECS::Service", 1)
+
+
+def test_fargate_task_definition_sizing(template):
+    template.has_resource_properties(
+        "AWS::ECS::TaskDefinition",
+        {
+            "Cpu": "512",
+            "Memory": "2048",
+            "RequiresCompatibilities": Match.array_with(["FARGATE"]),
+        },
+    )
+
+
+def test_internet_facing_alb(template):
+    template.has_resource_properties(
+        "AWS::ElasticLoadBalancingV2::LoadBalancer",
+        {"Scheme": "internet-facing"},
+    )
+
+
+def test_https_listener_on_443(template):
+    template.has_resource_properties(
+        "AWS::ElasticLoadBalancingV2::Listener",
+        {"Protocol": "HTTPS", "Port": 443},
+    )
+
+
+def test_cognito_user_pool_present(template):
+    template.resource_count_is("AWS::Cognito::UserPool", 1)
+
+
+def test_cognito_user_pool_client_present(template):
+    template.resource_count_is("AWS::Cognito::UserPoolClient", 1)
+
+
+def test_cognito_user_pool_domain_present(template):
+    template.resource_count_is("AWS::Cognito::UserPoolDomain", 1)
+
+
+def test_efs_encrypted_with_kms(template):
+    template.has_resource_properties(
+        "AWS::EFS::FileSystem",
+        {"Encrypted": True, "KmsKeyId": Match.any_value()},
+    )
+    template.resource_count_is("AWS::KMS::Key", 1)
+
+
+def test_at_least_two_iam_roles(template):
+    roles = template.find_resources("AWS::IAM::Role")
+    assert len(roles) >= 2
+
+
+def test_old_hardcoded_password_absent(template):
+    rendered = str(template.to_json())
+    assert OLD_HARDCODED_PASSWORD not in rendered


### PR DESCRIPTION
## Summary

Modernizes the Jupyter-on-ECS CDK project and removes a hardcoded secret.

- **CDK v1 → v2 migration**: imports now use `aws-cdk-lib` (`Stack`, `RemovalPolicy`, `CfnOutput` from `aws_cdk`) and `constructs`; `SubnetType.PRIVATE` → `PRIVATE_WITH_EGRESS`; removed deprecated `trust_account_identities`; `app.py` uses `import aws_cdk as cdk`; `cdk.json` trimmed of v1 feature flags and given a minimal modern context.
- **Secret removal**: the admin temporary password is no longer hardcoded in `config.yaml`. It is read from the `JUPYTER_ADMIN_TEMP_PASSWORD` env var (fail-fast if unset). The deployer IP is overridable via `DEPLOYER_IP_CIDR`, otherwise resolved at synth time.
- **Dependency + Python bump**: `aws-cdk-lib>=2.100.0,<3`, `constructs>=10,<11`, `PyYAML>=6` across `cdk/setup.py`, `requirements.txt`, `requirements-dev.txt`, and `Pipfile` (source → pypi.org, `boto3>=1.34,<2`, `python_version="3.11"`); `python_requires>=3.9`, classifiers 3.9–3.13.
- **Tests**: new pytest suite using `aws_cdk.assertions.Template` asserting ECS service, Fargate task def (Cpu 512 / Memory 2048), internet-facing ALB, HTTPS:443 listener, Cognito UserPool + Client + Domain, encrypted EFS + KMS key, and ≥2 IAM roles — plus a regression test that the old password string never appears in the synthesized template. `conftest.py` fixes `sys.path` and cwd.
- **CI/automation**: GitHub Actions matrix (Python 3.9–3.13) running `pytest --cov=cdk` then `cdk synth`; Dependabot for pip and github-actions (weekly).

## Verification (local)

- `pytest --cov=cdk`: **10 passed**, stack coverage **96%** (90% total incl. `setup.py`).
- `cdk synth` (with `JUPYTER_ADMIN_TEMP_PASSWORD` + `DEPLOYER_IP_CIDR` set): **exit 0**, template generated, old password confirmed absent from output.

> ⚠️ The hardcoded admin password is removed from current files here, but a git-history scrub (filter-repo + force-push) is still pending and will be handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)